### PR TITLE
Fix data filenames for case sensitive filesystems

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -67,7 +67,7 @@ pub fn build_output_file(data_dir: &path::Path) -> Result<path::PathBuf, Box<dyn
             let file_name = format!("{}{}", dir_name, file_num);
 
             // Add the file suffix and check the file exists
-            let file_path = match_dir.join(&format!("{}{}", file_name, os::FILE_SUFFIX));
+            let file_path = match_dir.join(&format!("{}{}", file_name.to_uppercase(), os::FILE_SUFFIX));
 
             if !file_path.is_file() {
                 continue;


### PR DESCRIPTION
Cool project!

```rust
// Add the file suffix and check the file exists
let file_path = match_dir.join(&format!("{}{}", file_name, os::FILE_SUFFIX));
```
This line produces filenames that look like `xx99.asc` but the ones extracted from the OS dataset look like `XX99.asc`. When using a case sensitive filesystem like ext4 or btrfs no data files are matched and an empty output binary is produced.

Converting `file_name` to uppercase here fixes this and lets me pass the tests.